### PR TITLE
Updated generate_rage_on_dmg_patch's gamedata

### DIFF
--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -766,22 +766,6 @@
 					"patch"			"\xEB" // unconditional JMP
 				}
 			}
-			"CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness"
-			{
-				"signature"			"CTFWeaponBase::ApplyOnHitAttributes()"
-				"linux"
-				{
-					"offset"		"8E2h"
-					"verify"		"\x74"
-					"patch"			"\xEB"
-				}
-				"windows"
-				{
-					"offset"		"C07h"	
-					"verify"		"\x74"
-					"patch"			"\xEB"
-				}
-			}
 		}
 		
 		"Signatures"
@@ -1072,12 +1056,6 @@
 				"library"	"server"
 				"linux"		"@_Z10JarExplodeiP9CTFPlayerP11CBaseEntityS2_RK6Vectorif7ETFCondfPKcS8_"
 				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x04\x89\x6C\x24\x04\x8B\xEC\x81\xEC\xD8\x01\x00\x00\x56\x57\x8D\x8D\x64\xFF\xFF\xFF"
-			}
-			"CTFWeaponBase::ApplyOnHitAttributes()"
-			{
-				"library"	"server"
-				"linux"		"@_ZN13CTFWeaponBase20ApplyOnHitAttributesEP11CBaseEntityP9CTFPlayerRK15CTakeDamageInfo"
-				"windows"	"\x55\x8B\xEC\x81\xEC\x10\x01\x00\x00\x53\x56\x57\x8B\x7D\x0C"
 			}
 		}
 		

--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -679,20 +679,22 @@
 				"signature"			"CTFGameRules::ApplyOnDamageAliveModifyRules()"
 				"linux"
 				{
-					"offset"		"1CD8h"
-					
+					// 95% sure about this
+					"offset"		"106Eh"
+
 					// mulss xmm2, *float == 0.5
-					"verify"		"\xF3\x0F\x59\x15\x2A\x2A\x2A\x2A"
+					"verify"		"\xF3\x0F\x59\x15\x6C\x2A\x2A\x2A"
+					// Original bytes xF3 x0F x59 x15 x6C xD5 x1D x01
 					
 					// nop out the multiply operand
 					"patch"			"\x90\x90\x90\x90\x90\x90\x90\x90"
 				}
 				"windows"
 				{
-					"offset"		"848h"
+					"offset"		"890h"
 					
 					// mulss xmm0, &float == 0.5
-					"verify"		"\xF3\x0F\x59\x05\x2A\x2A\x2A\x2A"
+					"verify"		"\xF3\x0F\x59\x05\xB0\x2A\x2A\x2A"
 					
 					// nop out the multiply operand
 					"patch"			"\x90\x90\x90\x90\x90\x90\x90\x90"
@@ -721,13 +723,13 @@
 				"signature"			"CTFPlayer::ApplyPushFromDamage()"
 				"linux"
 				{
-					"offset"		"1988"
-					"verify"		"\x74"
+					"offset"		"7BAh"
+					"verify"		"\x0F"
 					"patch"			"\x71"
 				}
 				"windows"
 				{
-					"offset"		"82Bh"
+					"offset"		"835h"
 					"verify"		"\x74"
 					"patch"			"\xEB" // unconditional JMP
 				}
@@ -897,7 +899,7 @@
 				// unuqie x-ref "damage_blast_push"
 				"library"	"server"
 				"linux"		"@_ZN9CTFPlayer19ApplyPushFromDamageERK15CTakeDamageInfo6Vector"
-				"windows"	"\x55\x8B\xEC\xA1\x2A\x2A\x2A\x2A\x83\xEC\x28\x83\x78\x30\x00\x53"
+				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x2A\x83\xEC\x28\x83\x78\x30\x00\x53\x56\x57\x8B\xF9"
 			}
 			"CTFPlayer::CreateRagdollEntity()"
 			{

--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -684,7 +684,6 @@
 
 					// mulss xmm2, *float == 0.5
 					"verify"		"\xF3\x0F\x59\x15\x6C\x2A\x2A\x2A"
-					// Original bytes xF3 x0F x59 x15 x6C xD5 x1D x01
 					
 					// nop out the multiply operand
 					"patch"			"\x90\x90\x90\x90\x90\x90\x90\x90"
@@ -724,7 +723,7 @@
 				"linux"
 				{
 					"offset"		"7BAh"
-					"verify"		"\x0F"
+					"verify"		"\x74"
 					"patch"			"\x71"
 				}
 				"windows"

--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -679,11 +679,10 @@
 				"signature"			"CTFGameRules::ApplyOnDamageAliveModifyRules()"
 				"linux"
 				{
-					// 95% sure about this
 					"offset"		"106Eh"
 
 					// mulss xmm2, *float == 0.5
-					"verify"		"\xF3\x0F\x59\x15\x6C\x2A\x2A\x2A"
+					"verify"		"\xF3\x0F\x59\x15\x2A\x2A\x2A\x2A"
 					
 					// nop out the multiply operand
 					"patch"			"\x90\x90\x90\x90\x90\x90\x90\x90"
@@ -722,7 +721,7 @@
 				"signature"			"CTFPlayer::ApplyPushFromDamage()"
 				"linux"
 				{
-					"offset"		"7BAh"
+					"offset"		"78Ch"
 					"verify"		"\x74"
 					"patch"			"\x71"
 				}

--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -680,7 +680,7 @@
 				"linux"
 				{
 					"offset"		"106Eh"
-
+					
 					// mulss xmm2, *float == 0.5
 					"verify"		"\xF3\x0F\x59\x15\x2A\x2A\x2A\x2A"
 					
@@ -692,7 +692,7 @@
 					"offset"		"890h"
 					
 					// mulss xmm0, &float == 0.5
-					"verify"		"\xF3\x0F\x59\x05\xB0\x2A\x2A\x2A"
+					"verify"		"\xF3\x0F\x59\x05\x2A\x2A\x2A\x2A"
 					
 					// nop out the multiply operand
 					"patch"			"\x90\x90\x90\x90\x90\x90\x90\x90"

--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -766,6 +766,22 @@
 					"patch"			"\xEB" // unconditional JMP
 				}
 			}
+			"CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness"
+			{
+				"signature"			"CTFWeaponBase::ApplyOnHitAttributes()"
+				"linux"
+				{
+					"offset"		"8E2h"
+					"verify"		"\x74"
+					"patch"			"\xEB"
+				}
+				"windows"
+				{
+					"offset"		"C07h"	
+					"verify"		"\x74"
+					"patch"			"\xEB"
+				}
+			}
 		}
 		
 		"Signatures"
@@ -1056,6 +1072,12 @@
 				"library"	"server"
 				"linux"		"@_Z10JarExplodeiP9CTFPlayerP11CBaseEntityS2_RK6Vectorif7ETFCondfPKcS8_"
 				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x04\x89\x6C\x24\x04\x8B\xEC\x81\xEC\xD8\x01\x00\x00\x56\x57\x8D\x8D\x64\xFF\xFF\xFF"
+			}
+			"CTFWeaponBase::ApplyOnHitAttributes()"
+			{
+				"library"	"server"
+				"linux"		"@_ZN13CTFWeaponBase20ApplyOnHitAttributesEP11CBaseEntityP9CTFPlayerRK15CTakeDamageInfo"
+				"windows"	"\x55\x8B\xEC\x81\xEC\x10\x01\x00\x00\x53\x56\x57\x8B\x7D\x0C"
 			}
 		}
 		

--- a/scripting/generate_rage_on_dmg_patch.sp
+++ b/scripting/generate_rage_on_dmg_patch.sp
@@ -21,6 +21,7 @@
 MemoryPatch g_PatchHandleRageGain;
 MemoryPatch g_PatchDisableHeavyRageKnockback;
 MemoryPatch g_PatchDisableHeavyRageDamagePenalty;
+MemoryPatch g_PatchDisableSlownessFromHeavyRage;
 
 public void OnPluginStart() {
 	Handle hGameConf = LoadGameConfigFile("tf2.cattr_starterpack");
@@ -40,14 +41,23 @@ public void OnPluginStart() {
 		SetFailState("Could not verify patch for "
 				... "CTFPlayer::ApplyPushFromDamage()::NoHeavyKnockbackRage");
 	}
-	
+
+	g_PatchDisableSlownessFromHeavyRage = MemoryPatch.CreateFromConf(hGameConf, 
+            "CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness");
+
+	if (!g_PatchDisableSlownessFromHeavyRage.Validate()) {
+        SetFailState("Could not verify patch for "
+                ... "CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness");
+    }
+
 	g_PatchDisableHeavyRageDamagePenalty = MemoryPatch.CreateFromConf(hGameConf,
 			"CTFGameRules::ApplyOnDamageAliveModifyRules()::DisableHeavyRageDamagePenalty");
+
 	if (!g_PatchDisableHeavyRageDamagePenalty.Validate()) {
 		SetFailState("Could not verify patch for CTFGameRules::ApplyOnDamageAliveModifyRules()"
 				... "::DisableHeavyRageDamagePenalty");
 	}
-	
+
 	Handle dtApplyOnDamageAliveModifyRules = DHookCreateFromConf(hGameConf,
 			"CTFGameRules::ApplyOnDamageAliveModifyRules()");
 	DHookEnableDetour(dtApplyOnDamageAliveModifyRules, false, OnApplyOnDamageModifyRulesPre);
@@ -102,6 +112,7 @@ public MRESReturn OnApplyPushFromDamagePre(int client, Handle hParams) {
 	
 	if (ReadIntVar(attr, "disable_knockback")) {
 		g_PatchDisableHeavyRageKnockback.Enable();
+		g_PatchDisableSlownessFromHeavyRage.Enable();
 	}
 	return MRES_Ignored;
 }

--- a/scripting/generate_rage_on_dmg_patch.sp
+++ b/scripting/generate_rage_on_dmg_patch.sp
@@ -21,7 +21,6 @@
 MemoryPatch g_PatchHandleRageGain;
 MemoryPatch g_PatchDisableHeavyRageKnockback;
 MemoryPatch g_PatchDisableHeavyRageDamagePenalty;
-MemoryPatch g_PatchDisableSlownessFromHeavyRage;
 
 public void OnPluginStart() {
 	Handle hGameConf = LoadGameConfigFile("tf2.cattr_starterpack");
@@ -41,23 +40,14 @@ public void OnPluginStart() {
 		SetFailState("Could not verify patch for "
 				... "CTFPlayer::ApplyPushFromDamage()::NoHeavyKnockbackRage");
 	}
-
-	g_PatchDisableSlownessFromHeavyRage = MemoryPatch.CreateFromConf(hGameConf, 
-            "CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness");
-
-	if (!g_PatchDisableSlownessFromHeavyRage.Validate()) {
-        SetFailState("Could not verify patch for "
-                ... "CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness");
-    }
-
+	
 	g_PatchDisableHeavyRageDamagePenalty = MemoryPatch.CreateFromConf(hGameConf,
 			"CTFGameRules::ApplyOnDamageAliveModifyRules()::DisableHeavyRageDamagePenalty");
-
 	if (!g_PatchDisableHeavyRageDamagePenalty.Validate()) {
 		SetFailState("Could not verify patch for CTFGameRules::ApplyOnDamageAliveModifyRules()"
 				... "::DisableHeavyRageDamagePenalty");
 	}
-
+	
 	Handle dtApplyOnDamageAliveModifyRules = DHookCreateFromConf(hGameConf,
 			"CTFGameRules::ApplyOnDamageAliveModifyRules()");
 	DHookEnableDetour(dtApplyOnDamageAliveModifyRules, false, OnApplyOnDamageModifyRulesPre);
@@ -112,7 +102,6 @@ public MRESReturn OnApplyPushFromDamagePre(int client, Handle hParams) {
 	
 	if (ReadIntVar(attr, "disable_knockback")) {
 		g_PatchDisableHeavyRageKnockback.Enable();
-		g_PatchDisableSlownessFromHeavyRage.Enable();
 	}
 	return MRES_Ignored;
 }


### PR DESCRIPTION
The **gamedata** that the plugin utilizes is wrong. Since I've fixed them on my server, thought that I'd fix them for everyone.
ApplyPushFromDamage() is most likely not even needed, but I had to change the first 6 bytes for my own server for the knockback modifier and added the last three bytes so the function can be found.

## BIG DISCLAIMER
I've tested the Windows ones since I run my server on Windows and I know they work, but I can't say the same thing for the Linux one. They should work, but I haven't tested. Sorry!

## LINUX

LINUX:
CTFGameRules::ApplyOnDamageAliveModifyRules()::DisableHeavyRageDamagePenalty
95% sure about it. The bytes in IDA are: xF3 x0F x59 x15 x6C xD5 x1D x01. Wildcarded the last three bytes like in the original gamedata.

CTFPlayer::ApplyPushFromDamage()::NoHeavyKnockbackRage
99% sure it's correct.