### PR TITLE
Remove the slow from heavy's rage

### DIFF
--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -777,7 +777,7 @@
 				}
 				"windows"
 				{
-					"offset"		"C07h"	
+					"offset"		"C07h"
 					"verify"		"\x74"
 					"patch"			"\xEB"
 				}

--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -765,6 +765,23 @@
 					"patch"			"\xEB" // unconditional JMP
 				}
 			}
+			"CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness"
+			{
+				// patch jump to prevent the slow cond on hit
+				"signature"			"CTFWeaponBase::ApplyOnHitAttributes()"
+				"linux"
+				{
+					"offset"		"8E2h"
+					"verify"		"\x74"
+					"patch"			"\xEB"
+				}
+				"windows"
+				{
+					"offset"		"C07h"	
+					"verify"		"\x74"
+					"patch"			"\xEB"
+				}
+			}
 		}
 		
 		"Signatures"
@@ -1055,6 +1072,12 @@
 				"library"	"server"
 				"linux"		"@_Z10JarExplodeiP9CTFPlayerP11CBaseEntityS2_RK6Vectorif7ETFCondfPKcS8_"
 				"windows"	"\x2A\x2A\x2A\x2A\x2A\x2A\x83\xE4\xF0\x83\xC4\x04\x55\x8B\x6B\x04\x89\x6C\x24\x04\x8B\xEC\x81\xEC\xD8\x01\x00\x00\x56\x57\x8D\x8D\x64\xFF\xFF\xFF"
+			}
+			"CTFWeaponBase::ApplyOnHitAttributes()"
+			{
+				"library"	"server"
+				"linux"		"@_ZN13CTFWeaponBase20ApplyOnHitAttributesEP11CBaseEntityP9CTFPlayerRK15CTakeDamageInfo"
+				"windows"	"\x55\x8B\xEC\x81\xEC\x10\x01\x00\x00\x53\x56\x57\x8B\x7D\x0C"
 			}
 		}
 		

--- a/scripting/generate_rage_on_dmg_patch.sp
+++ b/scripting/generate_rage_on_dmg_patch.sp
@@ -21,33 +21,45 @@
 MemoryPatch g_PatchHandleRageGain;
 MemoryPatch g_PatchDisableHeavyRageKnockback;
 MemoryPatch g_PatchDisableHeavyRageDamagePenalty;
+MemoryPatch g_PatchDisableSlownessFromHeavyRage;
 
 public void OnPluginStart() {
 	Handle hGameConf = LoadGameConfigFile("tf2.cattr_starterpack");
 	if (!hGameConf) {
 		SetFailState("Failed to load gamedata (tf2.cattr_starterpack).");
 	}
-	
+
 	g_PatchHandleRageGain = MemoryPatch.CreateFromConf(hGameConf,
 			"HandleRageGain()::NoHeavyRageGain");
+
 	if (!g_PatchHandleRageGain.Validate()) {
 		SetFailState("Could not verify patch for HandleRageGain()::NoHeavyRageGain");
 	}
-	
+
 	g_PatchDisableHeavyRageKnockback = MemoryPatch.CreateFromConf(hGameConf,
 			"CTFPlayer::ApplyPushFromDamage()::NoHeavyKnockbackRage");
+
 	if (!g_PatchDisableHeavyRageKnockback.Validate()) {
 		SetFailState("Could not verify patch for "
 				... "CTFPlayer::ApplyPushFromDamage()::NoHeavyKnockbackRage");
 	}
-	
+
+	g_PatchDisableSlownessFromHeavyRage = MemoryPatch.CreateFromConf(hGameConf, 
+			"CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness");
+
+	if (!g_PatchDisableSlownessFromHeavyRage.Validate()) {
+		SetFailState("Could not verify patch for "
+				... "CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness");
+	}
+
 	g_PatchDisableHeavyRageDamagePenalty = MemoryPatch.CreateFromConf(hGameConf,
 			"CTFGameRules::ApplyOnDamageAliveModifyRules()::DisableHeavyRageDamagePenalty");
+
 	if (!g_PatchDisableHeavyRageDamagePenalty.Validate()) {
 		SetFailState("Could not verify patch for CTFGameRules::ApplyOnDamageAliveModifyRules()"
-				... "::DisableHeavyRageDamagePenalty");
+			... "::DisableHeavyRageDamagePenalty");
 	}
-	
+
 	Handle dtApplyOnDamageAliveModifyRules = DHookCreateFromConf(hGameConf,
 			"CTFGameRules::ApplyOnDamageAliveModifyRules()");
 	DHookEnableDetour(dtApplyOnDamageAliveModifyRules, false, OnApplyOnDamageModifyRulesPre);
@@ -102,6 +114,7 @@ public MRESReturn OnApplyPushFromDamagePre(int client, Handle hParams) {
 	
 	if (ReadIntVar(attr, "disable_knockback")) {
 		g_PatchDisableHeavyRageKnockback.Enable();
+		g_PatchDisableSlownessFromHeavyRage.Enable();
 	}
 	return MRES_Ignored;
 }

--- a/scripting/generate_rage_on_dmg_patch.sp
+++ b/scripting/generate_rage_on_dmg_patch.sp
@@ -57,7 +57,7 @@ public void OnPluginStart() {
 
 	if (!g_PatchDisableHeavyRageDamagePenalty.Validate()) {
 		SetFailState("Could not verify patch for CTFGameRules::ApplyOnDamageAliveModifyRules()"
-			... "::DisableHeavyRageDamagePenalty");
+				... "::DisableHeavyRageDamagePenalty");
 	}
 
 	Handle dtApplyOnDamageAliveModifyRules = DHookCreateFromConf(hGameConf,

--- a/scripting/generate_rage_on_dmg_patch.sp
+++ b/scripting/generate_rage_on_dmg_patch.sp
@@ -28,38 +28,34 @@ public void OnPluginStart() {
 	if (!hGameConf) {
 		SetFailState("Failed to load gamedata (tf2.cattr_starterpack).");
 	}
-
+	
 	g_PatchHandleRageGain = MemoryPatch.CreateFromConf(hGameConf,
 			"HandleRageGain()::NoHeavyRageGain");
-
 	if (!g_PatchHandleRageGain.Validate()) {
 		SetFailState("Could not verify patch for HandleRageGain()::NoHeavyRageGain");
 	}
-
+	
 	g_PatchDisableHeavyRageKnockback = MemoryPatch.CreateFromConf(hGameConf,
 			"CTFPlayer::ApplyPushFromDamage()::NoHeavyKnockbackRage");
-
 	if (!g_PatchDisableHeavyRageKnockback.Validate()) {
 		SetFailState("Could not verify patch for "
 				... "CTFPlayer::ApplyPushFromDamage()::NoHeavyKnockbackRage");
 	}
-
-	g_PatchDisableSlownessFromHeavyRage = MemoryPatch.CreateFromConf(hGameConf, 
+	
+	g_PatchDisableSlownessFromHeavyRage = MemoryPatch.CreateFromConf(hGameConf,
 			"CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness");
-
 	if (!g_PatchDisableSlownessFromHeavyRage.Validate()) {
 		SetFailState("Could not verify patch for "
 				... "CTFWeaponBase::ApplyOnHitAttributes()::RemoveSlowness");
 	}
-
+	
 	g_PatchDisableHeavyRageDamagePenalty = MemoryPatch.CreateFromConf(hGameConf,
 			"CTFGameRules::ApplyOnDamageAliveModifyRules()::DisableHeavyRageDamagePenalty");
-
 	if (!g_PatchDisableHeavyRageDamagePenalty.Validate()) {
 		SetFailState("Could not verify patch for CTFGameRules::ApplyOnDamageAliveModifyRules()"
 				... "::DisableHeavyRageDamagePenalty");
 	}
-
+	
 	Handle dtApplyOnDamageAliveModifyRules = DHookCreateFromConf(hGameConf,
 			"CTFGameRules::ApplyOnDamageAliveModifyRules()");
 	DHookEnableDetour(dtApplyOnDamageAliveModifyRules, false, OnApplyOnDamageModifyRulesPre);


### PR DESCRIPTION
## Remove the slow from heavy's rage

During heavy's rage, players that get hit get slowed for 0.25 seconds by 100%. They can't move. This patches over that part so it doesn't happen.
I wrote a standalone plugin to do this for my server, but decided to port it to generate_rage_on_dmg_patch.sp since it makes more sense.

## Gamedata
The windows gamedata is correct. The Linux one should be too, but it's untested.

## Details

This is part of the code in **CTFWeaponBase::ApplyOnHitAttributes()** that causes it.

```
int iRageStun = 0;
CALL_ATTRIB_HOOK_INT_ON_OTHER( pAttacker, iRageStun, generate_rage_on_dmg );
if ( iRageStun && pAttacker->m_Shared.IsRageDraining() )
{
	// MvM: Heavies can purchase a rage-based knockback+stun effect
	if ( pAttacker->IsPlayerClass( TF_CLASS_HEAVYWEAPONS ) )
	{
		int iStunFlags = TF_STUN_MOVEMENT | TF_STUN_NO_EFFECTS;
		pVictim->m_Shared.StunPlayer( 0.25f, 1.f, iStunFlags, pAttacker );
	}
}
```