### PR TITLE
Fixed the drain being able to remove players' ubercharge

### DIFF
--- a/gamedata/tf2.cattr_starterpack.txt
+++ b/gamedata/tf2.cattr_starterpack.txt
@@ -670,6 +670,36 @@
 					}
 				}
 			}
+			"CTFPlayerShared::RecalculateChargeEffects()"
+			{
+				"signature"		"CTFPlayerShared::RecalculateChargeEffects()"
+				"callconv"		"thiscall"
+				"return"		"void"
+				"this"			"address"
+				
+				"arguments"
+				{
+					"bInstantRemove"
+					{
+						"type"	"bool"
+					}
+				}
+			}
+			"CTFPlayerShared::StopHealing()"
+			{
+				"signature"		"CTFPlayerShared::StopHealing()"
+				"callconv"		"thiscall"
+				"return"		"void"
+				"this"			"address"
+				
+				"arguments"
+				{
+					"pHealer"
+					{
+						"type"	"cbaseentity"
+					}
+				}
+			}
 		}
 		
 		"MemPatches"
@@ -1077,6 +1107,12 @@
 				"library"	"server"
 				"linux"		"@_ZN13CTFWeaponBase20ApplyOnHitAttributesEP11CBaseEntityP9CTFPlayerRK15CTakeDamageInfo"
 				"windows"	"\x55\x8B\xEC\x81\xEC\x10\x01\x00\x00\x53\x56\x57\x8B\x7D\x0C"
+			}
+			"CTFPlayerShared::RecalculateChargeEffects()"
+			{
+				"library"	"server"
+				"linux"		"@_ZN15CTFPlayerShared24RecalculateChargeEffectsEb"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x38\x53\x56\x57\x8B\xF9\xC7\x45\xCC\x00\x00\x00\x00"
 			}
 		}
 		

--- a/scripting/joke_medigun_mod_drain_health.sp
+++ b/scripting/joke_medigun_mod_drain_health.sp
@@ -56,7 +56,7 @@ public void OnPluginStart() {
 	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_Plain);
 	g_SDKCallFindEntityInSphere = EndPrepSDKCall();
 
-	if(!g_SDKCallFindEntityInSphere) {
+	if (!g_SDKCallFindEntityInSphere) {
 		SetFailState("Failed to setup SDKCall for CGlobalEntityList::FindEntityInSphere()");
 	}
 	
@@ -66,17 +66,16 @@ public void OnPluginStart() {
 	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
 	g_SDKCallGetCombatCharacterPtr = EndPrepSDKCall();
 
-	if(!g_SDKCallGetCombatCharacterPtr) {
+	if (!g_SDKCallGetCombatCharacterPtr) {
 		SetFailState("Failed to setup SDKCall for CBaseEntity::MyCombatCharacterPointer()");
 	}
 
 	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, 
-			"CBaseEntity::GetBaseEntity()");
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, "CBaseEntity::GetBaseEntity()");
 	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
 	g_SDKCallGetBaseEntity = EndPrepSDKCall();
 
-	if(!g_SDKCallGetBaseEntity) {
+	if (!g_SDKCallGetBaseEntity) {
 		SetFailState("Failed to setup SDKCall for CBaseEntity::GetBaseEntity()");
 	}
 	
@@ -119,7 +118,7 @@ public void OnPluginStart() {
 	g_DHookWeaponPostFrame = DHookCreateFromConf(hGameConf,
 			"CBaseCombatWeapon::ItemPostFrame()");
 
-	if(!g_DHookWeaponPostFrame) {
+	if (!g_DHookWeaponPostFrame) {
 		SetFailState("Failed to setup detour for CBaseCombatWeapon::ItemPostFrame()");
 	}
 	
@@ -212,13 +211,12 @@ public MRESReturn OnAllowedToHealTargetPre(int medigun, Handle hReturn, Handle h
 	int healer = TF2_GetEntityOwner(medigun);
 	int target = DHookGetParam(hParams, 1);
 
-	if(!IsValidClient(healer) || !IsValidClient(target)) {
+	if (!IsValidClient(healer) || !IsValidClient(target)) {
 		DHookSetReturn(hReturn, false);
-
 		return MRES_Supercede;
 	}
 
-	if(IsTargetInUberState(target) || TF2_IsPlayerInCondition(target, TFCond_Cloaked)) {
+	if (IsTargetInUberState(target) || TF2_IsPlayerInCondition(target, TFCond_Cloaked)) {
 		DHookSetReturn(hReturn, false);
 		return MRES_Supercede;
 	}
@@ -235,37 +233,36 @@ public MRESReturn OnRecalculateChargeEffectsPre(Address pPlayerShared, DHookPara
 
 	bool bIsPlayerBeingDrained = false;
 
-	if(!IsValidClient(client)) {
+	if (!IsValidClient(client)) {
 		return MRES_Ignored;
 	}
 
 	int numHealers = GetEntProp(client, Prop_Send, "m_nNumHealers");
 
-	for(int i = 0; i < numHealers; i++) {
+	for (int i = 0; i < numHealers; i++) {
 		int healer = GetHealerByIndex(client, i);
-		if(!IsValidClient(healer)) {
+		if (!IsValidClient(healer)) {
 			return MRES_Ignored;
 		}
 
 		int weapon = TF2_GetClientActiveWeapon(healer);
-		if(weapon <= 0 || !IsValidEntity(weapon)) {
+		if (!weapon || !IsValidEntity(weapon)) {
 			return MRES_Ignored;
 		}
 
-		if(!bIsPlayerDraining[healer]) {
+		if (!bIsPlayerDraining[healer]) {
 			return MRES_Ignored;
 		}
 
-		if(IsTargetInUberState(client)) {
-			if(HasEntProp(weapon, Prop_Send, "m_hHealingTarget")) {
+		if (IsTargetInUberState(client)) {
+			if (HasEntProp(weapon, Prop_Send, "m_hHealingTarget")) {
 				SetEntPropEnt(weapon, Prop_Send, "m_hHealingTarget", -1);
 			}
-
 			bIsPlayerBeingDrained = true;
 		}
 	}
 
-	if(bIsPlayerBeingDrained) {
+	if (bIsPlayerBeingDrained) {
 		return MRES_Supercede;
 	}
 
@@ -274,8 +271,9 @@ public MRESReturn OnRecalculateChargeEffectsPre(Address pPlayerShared, DHookPara
 
 public MRESReturn OnMedigunPostFramePost(int medigun) {
 	int healer = TF2_GetEntityOwner(medigun);
-	if(!bIsPlayerDraining[healer])
+	if (!bIsPlayerDraining[healer]) {
 		return MRES_Ignored;
+	}
 
 	int healTarget = GetEntPropEnt(medigun, Prop_Send, "m_hHealingTarget");
 	if (!IsValidClient(healTarget)) {
@@ -309,19 +307,18 @@ public MRESReturn OnMedigunPostFramePost(int medigun) {
 	return MRES_Ignored;
 }
 
-public MRESReturn OnStopHealingPre(Address pPlayerShared, DHookParam hParams)
-{
+public MRESReturn OnStopHealingPre(Address pPlayerShared, DHookParam hParams) {
 	int healer = DHookGetParam(hParams, 1);
-	if(!IsValidClient(healer)) {
+	if (!IsValidClient(healer)) {
 		return MRES_Ignored;
 	}
 
 	int iWeapon = GetPlayerWeaponSlot(healer, 1);
-	if(iWeapon <= 0 || !IsValidEntity(iWeapon) || !TF2Util_IsEntityWeapon(iWeapon)) {
+	if (iWeapon <= 0 || !IsValidEntity(iWeapon) || !TF2Util_IsEntityWeapon(iWeapon)) {
 		return MRES_Ignored;
 	}
 
-	if(!TF2CustAttr_GetFloat(iWeapon, "medigun drains health")) {
+	if (!TF2CustAttr_GetFloat(iWeapon, "medigun drains health")) {
 		return MRES_Ignored;
 	}
 
@@ -437,11 +434,11 @@ stock int GetEntityFromAddress(Address pEntity)  {
 }
 
 stock bool IsValidClient(int client) {
-	if(client <= 0 || client > MaxClients) {
+	if (client <= 0 || client > MaxClients) {
 		return false;
 	}
 
-	if(!IsClientInGame(client)) {
+	if (!IsClientInGame(client)) {
 		return false;
 	}
 	

--- a/scripting/joke_medigun_mod_drain_health.sp
+++ b/scripting/joke_medigun_mod_drain_health.sp
@@ -17,14 +17,20 @@
 #include <stocksoup/tf/entity_prop_stocks>
 #include <stocksoup/tf/tempents_stocks>
 #include <smlib/clients>
+#include <tf2utils>
 
 Handle g_DHookWeaponPostFrame;
 Handle g_SDKCallFindEntityInSphere;
 Handle g_SDKCallGetCombatCharacterPtr;
+Handle g_SDKCallGetBaseEntity;
 
 // read from CTFPlayer::DeathSound() disasm
 // TODO actually read from gameconf? have to find windows sigs if I did
 int offs_CTFPlayer_LastDamageType = 0x2168;
+
+Address g_offset_CTFPlayerShared_pOuter;
+
+bool bIsPlayerDraining[MAXPLAYERS];
 
 char g_MedicScripts[][] = {
 	"medic_sf13_influx_big03",
@@ -49,25 +55,80 @@ public void OnPluginStart() {
 	PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef);
 	PrepSDKCall_AddParameter(SDKType_Float, SDKPass_Plain);
 	g_SDKCallFindEntityInSphere = EndPrepSDKCall();
+
+	if(!g_SDKCallFindEntityInSphere) {
+		SetFailState("Failed to setup SDKCall for CGlobalEntityList::FindEntityInSphere()");
+	}
 	
 	StartPrepSDKCall(SDKCall_Entity);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual,
 			"CBaseEntity::MyCombatCharacterPointer()");
 	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
 	g_SDKCallGetCombatCharacterPtr = EndPrepSDKCall();
+
+	if(!g_SDKCallGetCombatCharacterPtr) {
+		SetFailState("Failed to setup SDKCall for CBaseEntity::MyCombatCharacterPointer()");
+	}
+
+	StartPrepSDKCall(SDKCall_Raw);
+	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Virtual, 
+			"CBaseEntity::GetBaseEntity()");
+	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
+	g_SDKCallGetBaseEntity = EndPrepSDKCall();
+
+	if(!g_SDKCallGetBaseEntity) {
+		SetFailState("Failed to setup SDKCall for CBaseEntity::GetBaseEntity()");
+	}
 	
 	Handle dtMedigunAllowedToHealTarget = DHookCreateFromConf(hGameConf,
 			"CWeaponMedigun::AllowedToHealTarget()");
+
+	if (!dtMedigunAllowedToHealTarget) {
+		SetFailState("Failed to setup detour for CWeaponMedigun::AllowedToHealTarget()");
+	}
+
 	DHookEnableDetour(dtMedigunAllowedToHealTarget, false, OnAllowedToHealTargetPre);
+
+	Handle dtRecalculateChargeEffects = DHookCreateFromConf(hGameConf,
+			"CTFPlayerShared::RecalculateChargeEffects()");
+
+	if (!dtRecalculateChargeEffects) {
+		SetFailState("Failed to setup detour for CTFPlayerShared::RecalculateChargeEffects()");
+	}
 	
+	DHookEnableDetour(dtRecalculateChargeEffects, false, OnRecalculateChargeEffectsPre);
+
+	Handle dtStopHealing = DHookCreateFromConf(hGameConf,
+			"CTFPlayerShared::StopHealing()");
+
+	if (!dtStopHealing) {
+		SetFailState("Failed to setup detour for CTFPlayerShared::StopHealing()");
+	}
+
+	DHookEnableDetour(dtStopHealing, false, OnStopHealingPre);
+
 	Handle dtMedigunSecondaryAttack = DHookCreateFromConf(hGameConf,
 			"CWeaponMedigun::SecondaryAttack()");
+
+	if (!dtMedigunSecondaryAttack) {
+		SetFailState("Failed to setup detour for CWeaponMedigun::SecondaryAttack()");
+	}
+
 	DHookEnableDetour(dtMedigunSecondaryAttack, false, OnMedigunSecondaryAttackPre);
 	
 	g_DHookWeaponPostFrame = DHookCreateFromConf(hGameConf,
 			"CBaseCombatWeapon::ItemPostFrame()");
+
+	if(!g_DHookWeaponPostFrame) {
+		SetFailState("Failed to setup detour for CBaseCombatWeapon::ItemPostFrame()");
+	}
 	
 	Handle dtCreateRagdoll = DHookCreateFromConf(hGameConf, "CTFPlayer::CreateRagdollEntity()");
+	
+	if (!dtCreateRagdoll) {
+		SetFailState("Failed to setup detour for CTFPlayer::CreateRagdollEntity()");
+	}
+
 	DHookEnableDetour(dtCreateRagdoll, false, OnCreateRagdollPre);
 	
 	int offslastDamage = FindSendPropInfo("CTFPlayer", "m_flMvMLastDamageTime");
@@ -76,6 +137,8 @@ public void OnPluginStart() {
 	}
 	
 	offs_CTFPlayer_LastDamageType = offslastDamage + 0x14;
+
+	g_offset_CTFPlayerShared_pOuter = view_as<Address>(GameConfGetOffset(hGameConf, "CTFPlayerShared::m_pOuter"));
 	
 	delete hGameConf;
 	
@@ -109,6 +172,11 @@ public void OnClientPutInServer(int client) {
 	SDKHook(client, SDKHook_OnTakeDamageAlivePost, OnTakeDamageAlivePost);
 }
 
+// CTFPlayerShared::StopHealing() doesn't get called when a player disconnects.
+public void OnClientDisconnect_Post(int iClient) {
+	bIsPlayerDraining[iClient] = false;
+}
+
 static bool s_ForceCritDeathSound;
 public void OnTakeDamageAlivePost(int victim, int attacker, int inflictor, float damage,
 		int damagetype) {
@@ -137,20 +205,80 @@ public MRESReturn OnCreateRagdollPre(int client, Handle hParams) {
 
 // setting this up as a post hook causes windows srcds to crash
 public MRESReturn OnAllowedToHealTargetPre(int medigun, Handle hReturn, Handle hParams) {
-	if (TF2CustAttr_GetFloat(medigun, "medigun drains health") == 0.0) {
+	if (!TF2CustAttr_GetFloat(medigun, "medigun drains health")) {
 		return MRES_Ignored;
 	}
+
+	int healer = TF2_GetEntityOwner(medigun);
 	int target = DHookGetParam(hParams, 1);
-	if (target > 0 && target <= MaxClients) {
-		DHookSetReturn(hReturn, true);
+
+	if(!IsValidClient(healer) || !IsValidClient(target)) {
+		DHookSetReturn(hReturn, false);
+
 		return MRES_Supercede;
 	}
+
+	if(IsTargetInUberState(target) || TF2_IsPlayerInCondition(target, TFCond_Cloaked)) {
+		DHookSetReturn(hReturn, false);
+		return MRES_Supercede;
+	}
+
+	DHookSetReturn(hReturn, true);
+
+	bIsPlayerDraining[healer] = true;
+
+	return MRES_Supercede;
+}
+
+public MRESReturn OnRecalculateChargeEffectsPre(Address pPlayerShared, DHookParam hParams) {
+	int client = GetClientFromPlayerShared(pPlayerShared);
+
+	bool bIsPlayerBeingDrained = false;
+
+	if(!IsValidClient(client)) {
+		return MRES_Ignored;
+	}
+
+	int numHealers = GetEntProp(client, Prop_Send, "m_nNumHealers");
+
+	for(int i = 0; i < numHealers; i++) {
+		int healer = GetHealerByIndex(client, i);
+		if(!IsValidClient(healer)) {
+			return MRES_Ignored;
+		}
+
+		int weapon = TF2_GetClientActiveWeapon(healer);
+		if(weapon <= 0 || !IsValidEntity(weapon)) {
+			return MRES_Ignored;
+		}
+
+		if(!bIsPlayerDraining[healer]) {
+			return MRES_Ignored;
+		}
+
+		if(IsTargetInUberState(client)) {
+			if(HasEntProp(weapon, Prop_Send, "m_hHealingTarget")) {
+				SetEntPropEnt(weapon, Prop_Send, "m_hHealingTarget", -1);
+			}
+
+			bIsPlayerBeingDrained = true;
+		}
+	}
+
+	if(bIsPlayerBeingDrained) {
+		return MRES_Supercede;
+	}
+
 	return MRES_Ignored;
 }
 
 public MRESReturn OnMedigunPostFramePost(int medigun) {
+	int healer = TF2_GetEntityOwner(medigun);
+	if(!bIsPlayerDraining[healer])
+		return MRES_Ignored;
+
 	int healTarget = GetEntPropEnt(medigun, Prop_Send, "m_hHealingTarget");
-	if (!IsValidEntity(healTarget) || healTarget < 1 || healTarget > MaxClients) {
+	if (!IsValidClient(healTarget)) {
 		// don't process non-client targets
 		return MRES_Ignored;
 	}
@@ -160,13 +288,11 @@ public MRESReturn OnMedigunPostFramePost(int medigun) {
 		return MRES_Ignored;
 	}
 	
-	int owner = TF2_GetEntityOwner(medigun);
-	
 	// TODO fix not being able to damage friendly players with owner set without friendlyfire??
 	
 	s_ForceGibRagdoll = cattr_medigun_drain_gratuitous_violence.BoolValue;
 	s_ForceCritDeathSound = cattr_medigun_drain_gratuitous_violence.BoolValue;
-	SDKHooks_TakeDamage(healTarget, medigun, owner, flDrainRate * GetGameFrameTime(),
+	SDKHooks_TakeDamage(healTarget, medigun, healer, flDrainRate * GetGameFrameTime(),
 			DMG_PREVENT_PHYSICS_FORCE | DMG_ALWAYSGIB);
 	s_ForceCritDeathSound = false;
 	s_ForceGibRagdoll = false;
@@ -180,6 +306,27 @@ public MRESReturn OnMedigunPostFramePost(int medigun) {
 		SetEntPropFloat(medigun, Prop_Send, "m_flChargeLevel", flChargeLevel);
 	}
 	
+	return MRES_Ignored;
+}
+
+public MRESReturn OnStopHealingPre(Address pPlayerShared, DHookParam hParams)
+{
+	int healer = DHookGetParam(hParams, 1);
+	if(!IsValidClient(healer)) {
+		return MRES_Ignored;
+	}
+
+	int iWeapon = GetPlayerWeaponSlot(healer, 1);
+	if(iWeapon <= 0 || !IsValidEntity(iWeapon) || !TF2Util_IsEntityWeapon(iWeapon)) {
+		return MRES_Ignored;
+	}
+
+	if(!TF2CustAttr_GetFloat(iWeapon, "medigun drains health")) {
+		return MRES_Ignored;
+	}
+
+	bIsPlayerDraining[healer] = false;
+
 	return MRES_Ignored;
 }
 
@@ -267,4 +414,44 @@ static int FindEntityInSphere(int startEntity, const float vecPosition[3], float
 
 bool IsEntityCombatCharacter(int entity) {
 	return SDKCall(g_SDKCallGetCombatCharacterPtr, entity) != Address_Null;
+}
+
+stock int GetClientFromPlayerShared(Address pPlayerShared)  {
+	Address pOuter = view_as<Address>(LoadFromAddress(pPlayerShared 
+				+ g_offset_CTFPlayerShared_pOuter, NumberType_Int32));
+
+	return GetEntityFromAddress(pOuter);
+}
+
+stock int GetHealerByIndex(int client, int index) {
+	int m_aHealers = FindSendPropInfo("CTFPlayer", "m_nNumHealers") + 12;
+	
+	Address m_Shared = GetEntityAddress(client) + view_as<Address>(m_aHealers);
+	Address aHealers = view_as<Address>(LoadFromAddress(m_Shared, NumberType_Int32));
+	
+	return (LoadFromAddress(aHealers + view_as<Address>(index * 0x24), NumberType_Int32) & 0xFFF);
+} 
+
+stock int GetEntityFromAddress(Address pEntity)  {
+	return SDKCall(g_SDKCallGetBaseEntity, pEntity);
+}
+
+stock bool IsValidClient(int client) {
+	if(client <= 0 || client > MaxClients) {
+		return false;
+	}
+
+	if(!IsClientInGame(client)) {
+		return false;
+	}
+	
+	return true;
+}
+
+stock bool IsTargetInUberState(int client) {
+	return (TF2_IsPlayerInCondition(client, TFCond_Ubercharged) 
+		 || TF2_IsPlayerInCondition(client, TFCond_UberchargeFading) 
+		 || TF2_IsPlayerInCondition(client, TFCond_UberchargedHidden) 
+		 || TF2_IsPlayerInCondition(client, TFCond_UberchargedCanteen) 
+		 || TF2_IsPlayerInCondition(client, TFCond_UberchargedOnTakeDamage));
 }

--- a/scripting/joke_medigun_mod_drain_health.sp
+++ b/scripting/joke_medigun_mod_drain_health.sp
@@ -228,7 +228,7 @@ public MRESReturn OnAllowedToHealTargetPre(int medigun, Handle hReturn, Handle h
 	return MRES_Supercede;
 }
 
-public MRESReturn OnRecalculateChargeEffectsPre(Address pPlayerShared, DHookParam hParams) {
+public MRESReturn OnRecalculateChargeEffectsPre(Address pPlayerShared, Handle hParams) {
 	int client = GetClientFromPlayerShared(pPlayerShared);
 
 	bool bIsPlayerBeingDrained = false;
@@ -307,7 +307,7 @@ public MRESReturn OnMedigunPostFramePost(int medigun) {
 	return MRES_Ignored;
 }
 
-public MRESReturn OnStopHealingPre(Address pPlayerShared, DHookParam hParams) {
+public MRESReturn OnStopHealingPre(Address pPlayerShared, Handle hParams) {
 	int healer = DHookGetParam(hParams, 1);
 	if (!IsEntityInGameClient(healer)) {
 		return MRES_Ignored;

--- a/scripting/joke_medigun_mod_drain_health.sp
+++ b/scripting/joke_medigun_mod_drain_health.sp
@@ -211,7 +211,7 @@ public MRESReturn OnAllowedToHealTargetPre(int medigun, Handle hReturn, Handle h
 	int healer = TF2_GetEntityOwner(medigun);
 	int target = DHookGetParam(hParams, 1);
 
-	if (!IsValidClient(healer) || !IsValidClient(target)) {
+	if (!IsEntityInGameClient(healer) || !IsEntityInGameClient(target)) {
 		DHookSetReturn(hReturn, false);
 		return MRES_Supercede;
 	}
@@ -233,7 +233,7 @@ public MRESReturn OnRecalculateChargeEffectsPre(Address pPlayerShared, DHookPara
 
 	bool bIsPlayerBeingDrained = false;
 
-	if (!IsValidClient(client)) {
+	if (!IsEntityInGameClient(client)) {
 		return MRES_Ignored;
 	}
 
@@ -241,7 +241,7 @@ public MRESReturn OnRecalculateChargeEffectsPre(Address pPlayerShared, DHookPara
 
 	for (int i = 0; i < numHealers; i++) {
 		int healer = GetHealerByIndex(client, i);
-		if (!IsValidClient(healer)) {
+		if (!IsEntityInGameClient(healer)) {
 			return MRES_Ignored;
 		}
 
@@ -276,7 +276,7 @@ public MRESReturn OnMedigunPostFramePost(int medigun) {
 	}
 
 	int healTarget = GetEntPropEnt(medigun, Prop_Send, "m_hHealingTarget");
-	if (!IsValidClient(healTarget)) {
+	if (!IsEntityInGameClient(healTarget)) {
 		// don't process non-client targets
 		return MRES_Ignored;
 	}
@@ -309,7 +309,7 @@ public MRESReturn OnMedigunPostFramePost(int medigun) {
 
 public MRESReturn OnStopHealingPre(Address pPlayerShared, DHookParam hParams) {
 	int healer = DHookGetParam(hParams, 1);
-	if (!IsValidClient(healer)) {
+	if (!IsEntityInGameClient(healer)) {
 		return MRES_Ignored;
 	}
 
@@ -433,12 +433,12 @@ stock int GetEntityFromAddress(Address pEntity)  {
 	return SDKCall(g_SDKCallGetBaseEntity, pEntity);
 }
 
-stock bool IsValidClient(int client) {
-	if (client <= 0 || client > MaxClients) {
+stock bool IsEntityInGameClient(int entity) {
+	if (entity <= 0 || entity > MaxClients) {
 		return false;
 	}
 
-	if (!IsClientInGame(client)) {
+	if (!IsClientInGame(entity)) {
 		return false;
 	}
 	


### PR DESCRIPTION
# Custom Attribute: medigun drains health
Mediguns with this custom attribute are able to remove a player's ubercharge simply by draining. 
This happens due to how `CTFPlayerShared::RecalculateChargeEffects()` handles it, which is fair since you're not supposed to drain people anyway.

I've been running this modified version on my server for two weeks or so and it works like a charm. No errors, no reports of it removing players' uber.
If you want I can update it to use DHook's methodmap, that's what I've done on my version.

I've tried my best to match the coding style you use.

I hope I haven't missed anything ( mainly in the gamedata file ). It should be everything.