### PR TITLE
Fix for multi sentries

### DIFF
--- a/scripting/owned_building_phasing.sp
+++ b/scripting/owned_building_phasing.sp
@@ -192,6 +192,10 @@ bool CanPhaseThroughObject(int client, int building) {
 		case TFObject_Dispenser: {
 			return g_fAllowPhaseTypes[client] & PHASE_ALLOW_DISPENSERS != 0;
 		}
+        //For plugins using sapper as a workaround to get additional sentry counts
+        case TFObject_Sapper: {
+			return g_fAllowPhaseTypes[client] & PHASE_ALLOW_SENTRIES != 0;
+		}
 	}
 	return false;
 }

--- a/scripting/owned_building_phasing.sp
+++ b/scripting/owned_building_phasing.sp
@@ -192,8 +192,8 @@ bool CanPhaseThroughObject(int client, int building) {
 		case TFObject_Dispenser: {
 			return g_fAllowPhaseTypes[client] & PHASE_ALLOW_DISPENSERS != 0;
 		}
-        //For plugins using sapper as a workaround to get additional sentry counts
-        case TFObject_Sapper: {
+		case TFObject_Sapper: {
+			// fix for plugins using sapper as a workaround to get additional sentry counts
 			return g_fAllowPhaseTypes[client] & PHASE_ALLOW_SENTRIES != 0;
 		}
 	}


### PR DESCRIPTION
This is just a simple fix for the multi sentry that uses TFOjbect_Sapper as a replacment to allow for more than 1 sentries to be built