### PR TITLE
Add missing include into package

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -128,6 +128,9 @@ copy_files = [
 	
 	'scripting/include/tf_cattr_buff_override.inc',
 	'scripting/include/tf_cattr_lunch_effect.inc',
+	'scripting/include/tf_cattr_ball_impact_effect.inc',
+
+	'scripting/shared/tf_var_strings.sp',
 ]
 
 include_dirs = [


### PR DESCRIPTION
Recently, I downloaded package to use `tf_cattr_ball_impact_effect.inc`. But package doesn't have that.
So I add `tf_cattr_ball_impact_effect.inc` and `shared/tf_var_strings.sp` into package.